### PR TITLE
Cross-section rendering

### DIFF
--- a/addons/4d/SConstruct
+++ b/addons/4d/SConstruct
@@ -25,6 +25,7 @@ env.Append(
         "../../physics/shapes",
         "../../render",
         "../../render/wireframe_canvas",
+        "../../render/cross_section"
     ]
 )
 
@@ -49,7 +50,9 @@ sources = (
     + Glob("../../physics/shapes/*.cpp")
     + Glob("../../render/*.cpp")
     + Glob("../../render/wireframe_canvas/*.cpp")
+    + Glob("../../render/cross_section/*.cpp")
 )
+
 
 env.Append(CPPDEFINES=["GDEXTENSION"])
 
@@ -131,6 +134,8 @@ env["BUILDERS"]["GLSL_HEADER"] = Builder(
     action=header_builders.build_raw_headers_action,
     suffix="glsl.gen.h",
 )
+
+env.GLSL_HEADER("../../render/cross_section/cross_section_shader.glsl")
 
 target_file_path = "../../editor/icons/editor_4d_icons.gen.h"
 icon_sources = Glob("icons/4D.svg") + Glob("icons/Node4D.svg")

--- a/addons/4d/doc_classes/Material4D.xml
+++ b/addons/4d/doc_classes/Material4D.xml
@@ -44,6 +44,12 @@
 				[b]Note:[/b] When making materials, use the high-level properties from the derived classes instead, such as [member WireMaterial4D.albedo_source] or [member TetraMaterial4D.albedo_source].
 			</description>
 		</method>
+		<method name="get_cross_section_material">
+			<return type="ShaderMaterial" />
+			<description>
+				Returns a 3D material to be used by the cross-section renderer. The returned material is automatically updated to match the properties of this material.
+			</description>
+		</method>
 		<method name="is_default_material" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/addons/4d/doc_classes/Mesh4D.xml
+++ b/addons/4d/doc_classes/Mesh4D.xml
@@ -27,6 +27,12 @@
 				Callback method that should return the vertices of a mesh. Do not call this method. This can be overridden by derived classes when creating a custom mesh type in GDScript or another scripting language. See [method get_vertices] for details of the returned data.
 			</description>
 		</method>
+		<method name="_update_cross_section_mesh" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Updates the 3D mesh this mesh uses for cross-section rendering. Can be called to force the cross-section mesh to be updated, but typically should only be called internally. Subclasses can override this, but most cases should be covered by the default implementation.
+			</description>
+		</method>
 		<method name="_validate_material_for_mesh" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="material" type="Material4D" />
@@ -46,6 +52,12 @@
 			<description>
 				Static helper method for deduplicating edge indices. This method ensures that each pair of two integers in the array is unique, and that the first index is less than the second index. This is useful for optimizing wireframe meshes by removing duplicate edges and ensuring a consistent order for each edge.
 				[b]Note[/b]: This only looks at edge indices. It does not remove duplicate vertices, nor does it have access to the vertices array.
+			</description>
+		</method>
+		<method name="get_cross_section_mesh">
+			<return type="ArrayMesh" />
+			<description>
+				Returns a 3D mesh that can be used to render 3D cross-sections of this mesh in the cross-section renderer. This mesh will only render properly with the cross-section material from [method Material4D.get_cross_section_material].
 			</description>
 		</method>
 		<method name="get_edge_indices">
@@ -82,6 +94,12 @@
 				If a mesh has valid data, the result of the validation will be cached until the mesh data changes, so this method may be called multiple times without performance concerns. This also means this method should be called after generating a mesh. This especially useful when generating a mesh on a thread; calling this on the thread will avoid stalling the main thread with mesh validation during rendering.
 			</description>
 		</method>
+		<method name="mark_cross_section_mesh_dirty">
+			<return type="void" />
+			<description>
+				Marks the cross-section mesh as dirty, meaning it needs to be updated. Must be called by subclasses whenever the underlying 4D mesh data changes.
+			</description>
+		</method>
 		<method name="reset_mesh_data_validation">
 			<return type="void" />
 			<description>
@@ -99,6 +117,12 @@
 			<return type="WireMesh4D" />
 			<description>
 				Converts this Mesh4D to a [WireMesh4D]. This method will use the best conversion available. For example, a [BoxTetraMesh4D] will be converted to a [BoxWireMesh4D]. If no specialized conversion is available, the method will return an [ArrayWireMesh4D]. See [method to_array_wire_mesh] for more details.
+			</description>
+		</method>
+		<method name="update_cross_section_mesh">
+			<return type="void" />
+			<description>
+				Updates the 3D mesh this mesh uses for cross-section rendering. Can be called to force the cross-section mesh to be updated, but typically should only be called internally.
 			</description>
 		</method>
 		<method name="validate_material_for_mesh">

--- a/addons/4d/doc_classes/TetraMaterial4D.xml
+++ b/addons/4d/doc_classes/TetraMaterial4D.xml
@@ -19,6 +19,9 @@
 		<member name="albedo_source" type="int" setter="set_albedo_source" getter="get_albedo_source" enum="TetraMaterial4D.TetraColorSource" default="0">
 			The albedo source of the material, an enum specific to tetrahedral meshes. Can be a single color, per-vertex, per-cell, per-cell UVW coordinates, 4D texture, or a combination of single color and the other color sources.
 		</member>
+		<member name="texture" type="Texture3D" setter="set_texture" getter="get_texture">
+			The albedo texture of the material as a Texture3D. Used by the cross-section renderer. Used when albedo_source is [constant TETRA_COLOR_SOURCE_CELL_UVW_ONLY] or [constant TETRA_COLOR_SOURCE_CELL_UVW_AND_SINGLE].
+		</member>
 	</members>
 	<constants>
 		<constant name="TETRA_COLOR_SOURCE_SINGLE_COLOR" value="0" enum="TetraColorSource">

--- a/model/material_4d.cpp
+++ b/model/material_4d.cpp
@@ -1,5 +1,6 @@
 #include "material_4d.h"
 
+#include "../render/cross_section/cross_section_shader.glsl.gen.h"
 #include "mesh_4d.h"
 
 Color Material4D::get_albedo_color_of_edge(const int64_t p_edge_index, const Ref<Mesh4D> &p_for_mesh) {
@@ -112,6 +113,7 @@ Material4D::ColorSourceFlags Material4D::get_albedo_source_flags() const {
 
 void Material4D::set_albedo_source_flags(const ColorSourceFlags p_albedo_source_flags) {
 	_albedo_source_flags = p_albedo_source_flags;
+	update_cross_section_material();
 }
 
 Color Material4D::get_albedo_color() const {
@@ -120,6 +122,7 @@ Color Material4D::get_albedo_color() const {
 
 void Material4D::set_albedo_color(const Color &p_albedo_color) {
 	_albedo_color = p_albedo_color;
+	update_cross_section_material();
 }
 
 PackedColorArray Material4D::get_albedo_color_array() const {
@@ -128,10 +131,12 @@ PackedColorArray Material4D::get_albedo_color_array() const {
 
 void Material4D::set_albedo_color_array(const PackedColorArray &p_albedo_color_array) {
 	_albedo_color_array = p_albedo_color_array;
+	update_cross_section_material();
 }
 
 void Material4D::append_albedo_color(const Color &p_albedo_color) {
 	_albedo_color_array.push_back(p_albedo_color);
+	update_cross_section_material();
 }
 
 void Material4D::resize_albedo_color_array(const int64_t p_size, const Color &p_fill_color) {
@@ -140,6 +145,30 @@ void Material4D::resize_albedo_color_array(const int64_t p_size, const Color &p_
 	for (int64_t i = existing_size; i < p_size; i++) {
 		_albedo_color_array.set(i, p_fill_color);
 	}
+	update_cross_section_material();
+}
+
+Ref<ShaderMaterial> Material4D::get_cross_section_material() {
+	if (_cross_section_material.is_null()) {
+		_cross_section_material.instantiate();
+		update_cross_section_material();
+	}
+	return _cross_section_material;
+}
+
+void Material4D::update_cross_section_material() {
+	if (_cross_section_material.is_null()) {
+		// Want to skip updating if we never access the cross section material, so leave uninitialized until first get.
+		return;
+	}
+	if (_cross_section_material->get_shader().is_null()) {
+		// TODO this re-compiles the shader for every material, should cache the Shader object somewhere.
+		Ref<Shader> cross_section_shader;
+		cross_section_shader.instantiate();
+		cross_section_shader->set_code(cross_section_shader_shader_glsl);
+		_cross_section_material->set_shader(cross_section_shader);
+	}
+	_cross_section_material->set_shader_parameter("albedo", get_albedo_color());
 }
 
 void Material4D::_bind_methods() {
@@ -157,6 +186,8 @@ void Material4D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_albedo_color_array", "albedo_color_array"), &Material4D::set_albedo_color_array);
 	ClassDB::bind_method(D_METHOD("append_albedo_color", "albedo_color"), &Material4D::append_albedo_color);
 	ClassDB::bind_method(D_METHOD("resize_albedo_color_array", "size", "fill_color"), &Material4D::resize_albedo_color_array, DEFVAL(Color(1, 1, 1, 1)));
+
+	ClassDB::bind_method(D_METHOD("get_cross_section_material"), &Material4D::get_cross_section_material);
 
 	BIND_ENUM_CONSTANT(COLOR_SOURCE_FLAG_SINGLE_COLOR);
 	BIND_ENUM_CONSTANT(COLOR_SOURCE_FLAG_PER_VERT);

--- a/model/material_4d.cpp
+++ b/model/material_4d.cpp
@@ -1,6 +1,5 @@
 #include "material_4d.h"
 
-#include "../render/cross_section/cross_section_shader.glsl.gen.h"
 #include "mesh_4d.h"
 
 Color Material4D::get_albedo_color_of_edge(const int64_t p_edge_index, const Ref<Mesh4D> &p_for_mesh) {
@@ -157,18 +156,6 @@ Ref<ShaderMaterial> Material4D::get_cross_section_material() {
 }
 
 void Material4D::update_cross_section_material() {
-	if (_cross_section_material.is_null()) {
-		// Want to skip updating if we never access the cross section material, so leave uninitialized until first get.
-		return;
-	}
-	if (_cross_section_material->get_shader().is_null()) {
-		// TODO this re-compiles the shader for every material, should cache the Shader object somewhere.
-		Ref<Shader> cross_section_shader;
-		cross_section_shader.instantiate();
-		cross_section_shader->set_code(cross_section_shader_shader_glsl);
-		_cross_section_material->set_shader(cross_section_shader);
-	}
-	_cross_section_material->set_shader_parameter("albedo", get_albedo_color());
 }
 
 void Material4D::_bind_methods() {

--- a/model/material_4d.h
+++ b/model/material_4d.h
@@ -4,9 +4,11 @@
 
 #if GDEXTENSION
 #include <godot_cpp/classes/resource.hpp>
+#include <godot_cpp/classes/shader_material.hpp>
 #include <godot_cpp/core/gdvirtual.gen.inc>
 #elif GODOT_MODULE
 #include "core/io/resource.h"
+#include "scene/resources/material.h"
 #endif
 
 class Mesh4D;
@@ -44,6 +46,10 @@ protected:
 	PackedColorArray _albedo_color_array;
 	Color _albedo_color = Color(1, 1, 1, 1);
 	ColorSourceFlags _albedo_source_flags = COLOR_SOURCE_FLAG_SINGLE_COLOR;
+	Ref<ShaderMaterial> _cross_section_material;
+
+	// Update _cross_section_material to match current settings on the material, skip if _cross_section_material is null.
+	virtual void update_cross_section_material();
 
 public:
 	virtual Color get_albedo_color_of_edge(const int64_t p_edge_index, const Ref<Mesh4D> &p_for_mesh);
@@ -60,6 +66,8 @@ public:
 	void set_albedo_color_array(const PackedColorArray &p_albedo_color_array);
 	void append_albedo_color(const Color &p_albedo_color);
 	void resize_albedo_color_array(const int64_t p_size, const Color &p_fill_color = Color(1, 1, 1, 1));
+
+	Ref<ShaderMaterial> get_cross_section_material();
 };
 
 VARIANT_ENUM_CAST(Material4D::ColorSourceFlags);

--- a/model/mesh_4d.cpp
+++ b/model/mesh_4d.cpp
@@ -58,6 +58,10 @@ bool Mesh4D::validate_mesh_data() {
 	return ret;
 }
 
+void Mesh4D::update_cross_section_mesh() {
+	GDVIRTUAL_CALL(_update_cross_section_mesh);
+}
+
 void Mesh4D::validate_material_for_mesh(const Ref<Material4D> &p_material) {
 	GDVIRTUAL_CALL(_validate_material_for_mesh, p_material);
 	const Material4D::ColorSourceFlags albedo_source_flags = p_material->get_albedo_source_flags();
@@ -93,6 +97,15 @@ Ref<WireMesh4D> Mesh4D::to_wire_mesh() {
 	return to_array_wire_mesh();
 }
 
+Ref<ArrayMesh> Mesh4D::get_cross_section_mesh() {
+	if (_is_cross_section_mesh_dirty || _cross_section_mesh.is_null()) {
+		_cross_section_mesh.instantiate();
+		update_cross_section_mesh();
+		_is_cross_section_mesh_dirty = false;
+	}
+	return _cross_section_mesh;
+}
+
 Ref<Material4D> Mesh4D::get_material() const {
 	return _material;
 }
@@ -126,9 +139,12 @@ void Mesh4D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_mesh_data_valid"), &Mesh4D::is_mesh_data_valid);
 	ClassDB::bind_method(D_METHOD("reset_mesh_data_validation"), &Mesh4D::reset_mesh_data_validation);
 	ClassDB::bind_method(D_METHOD("validate_material_for_mesh", "material"), &Mesh4D::validate_material_for_mesh);
+	ClassDB::bind_method(D_METHOD("mark_cross_section_mesh_dirty"), &Mesh4D::mark_cross_section_mesh_dirty);
+	ClassDB::bind_method(D_METHOD("update_cross_section_mesh"), &Mesh4D::update_cross_section_mesh);
 
 	ClassDB::bind_method(D_METHOD("to_array_wire_mesh"), &Mesh4D::to_array_wire_mesh);
 	ClassDB::bind_method(D_METHOD("to_wire_mesh"), &Mesh4D::to_wire_mesh);
+	ClassDB::bind_method(D_METHOD("get_cross_section_mesh"), &Mesh4D::get_cross_section_mesh);
 
 	ClassDB::bind_method(D_METHOD("get_material"), &Mesh4D::get_material);
 	ClassDB::bind_method(D_METHOD("set_material", "material"), &Mesh4D::set_material);
@@ -143,4 +159,5 @@ void Mesh4D::_bind_methods() {
 	GDVIRTUAL_BIND(_get_vertices);
 	GDVIRTUAL_BIND(_validate_material_for_mesh, "material");
 	GDVIRTUAL_BIND(_validate_mesh_data);
+	GDVIRTUAL_BIND(_update_cross_section_mesh);
 }

--- a/model/mesh_4d.h
+++ b/model/mesh_4d.h
@@ -2,6 +2,12 @@
 
 #include "material_4d.h"
 
+#if GDEXTENSION
+#include <godot_cpp/classes/array_mesh.hpp>
+#elif GODOT_MODULE
+#include "scene/resources/mesh.h"
+#endif
+
 class ArrayWireMesh4D;
 class WireMesh4D;
 
@@ -10,10 +16,19 @@ class Mesh4D : public Resource {
 
 	Ref<Material4D> _material;
 	bool _is_mesh_data_valid = false;
+	bool _is_cross_section_mesh_dirty = true;
 
 protected:
+	Ref<ArrayMesh> _cross_section_mesh;
+
 	static void _bind_methods();
 	virtual bool validate_mesh_data();
+	// Call when the mesh is modified to indicate that
+	// the 3D mesh used for cross-section rendering needs to be updated.
+	void mark_cross_section_mesh_dirty() { _is_cross_section_mesh_dirty = true; };
+	// Called when the cross-section mesh is requested and the cross-section mesh has been marked dirty.
+	// Update the mesh referenced by _cross_section_mesh to match the current state of the mesh.
+	virtual void update_cross_section_mesh();
 
 public:
 	static PackedInt32Array deduplicate_edge_indices(const PackedInt32Array &p_items);
@@ -25,6 +40,8 @@ public:
 
 	Ref<ArrayWireMesh4D> to_array_wire_mesh();
 	virtual Ref<WireMesh4D> to_wire_mesh();
+	// Returns a reference to the mesh used for cross-section rendering.
+	Ref<ArrayMesh> get_cross_section_mesh();
 
 	Ref<Material4D> get_material() const;
 	void set_material(const Ref<Material4D> &p_material);
@@ -37,5 +54,6 @@ public:
 	GDVIRTUAL0R(PackedVector4Array, _get_edge_positions);
 	GDVIRTUAL0R(PackedVector4Array, _get_vertices);
 	GDVIRTUAL0R(bool, _validate_mesh_data);
+	GDVIRTUAL0(_update_cross_section_mesh);
 	GDVIRTUAL1(_validate_material_for_mesh, const Ref<Material4D> &);
 };

--- a/model/tetra/tetra_material_4d.h
+++ b/model/tetra/tetra_material_4d.h
@@ -2,6 +2,12 @@
 
 #include "../material_4d.h"
 
+#if GODOT_MODULE
+#include "scene/resources/texture.h"
+#elif GDEXTENSION
+#include <godot_cpp/classes/texture3d.hpp>
+#endif
+
 class TetraMaterial4D : public Material4D {
 	GDCLASS(TetraMaterial4D, Material4D);
 
@@ -20,6 +26,7 @@ public:
 
 private:
 	TetraColorSource _albedo_source = TETRA_COLOR_SOURCE_SINGLE_COLOR;
+	Ref<Texture3D> _texture;
 
 	static Material4D::ColorSourceFlags _tetra_source_to_flags(const TetraColorSource p_tetra_source);
 
@@ -27,12 +34,17 @@ protected:
 	static void _bind_methods();
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	void update_cross_section_material() override;
+
 public:
 	virtual Color get_albedo_color_of_edge(const int64_t p_edge_index, const Ref<Mesh4D> &p_for_mesh) override;
 	virtual void merge_with(const Ref<Material4D> &p_material, const int p_first_item_count, const int p_second_item_count) override;
 
 	TetraColorSource get_albedo_source() const;
 	void set_albedo_source(const TetraColorSource p_albedo_source);
+
+	Ref<Texture3D> get_texture() const;
+	void set_texture(const Ref<Texture3D> &p_texture);
 
 	TetraMaterial4D();
 };

--- a/model/tetra/tetra_mesh_4d.cpp
+++ b/model/tetra/tetra_mesh_4d.cpp
@@ -171,9 +171,9 @@ void TetraMesh4D::update_cross_section_mesh() {
 		// - Vertex position (3)
 		// - Custom 0-3 (4 * 4)
 		// - UV1 and UV2 (2 * 2)
-		// - Normal (3)
-		// - Tangent (3)
-		// - Color (4)
+		// - Normal (3), gets normalized so ~2 slots for arbitrary floats
+		// - Tangent (3), also gets normalized
+		// - Color (4), gets clamped to [0, 1]
 		// Slots that don't work:
 		// - Bone weights: get truncated, sorted, and normalized automatically
 		// - Binormal: available in shader, but computed in SurfaceTool from normal/tangent
@@ -190,14 +190,17 @@ void TetraMesh4D::update_cross_section_mesh() {
 		surface_tool->set_custom(2, Vector4D::to_color(vertices[cell_indices[i + 2]]));
 		surface_tool->set_custom(3, Vector4D::to_color(vertices[cell_indices[i + 3]]));
 
-		// UVW texture coords, need 4*3 float slots.  Using UV, UV2, Normal, Color, and one vertex.y.
-		Vector3 uvw1 = cell_uvws[cell_indices[i]];
-		Vector3 uvw2 = cell_uvws[cell_indices[i + 1]];
-		Vector3 uvw3 = cell_uvws[cell_indices[i + 2]];
-		Vector3 uvw4 = cell_uvws[cell_indices[i + 3]];
+		// UVW texture coords, need 4*3 float slots.  Using UV, UV2, Normal, Color, vertex.y, and vertex.z.
+		// Normal gets normalized somewhere in the pipeline, so last coord of 1.0 will get set to whatever we need to divide by to get
+		// to get the original coords.
+		Vector3 uvw1 = cell_uvws[i];
+		Vector3 uvw2 = cell_uvws[i + 1];
+		Vector3 uvw3 = cell_uvws[i + 2];
+		Vector3 uvw4 = cell_uvws[i + 3];
 		surface_tool->set_uv(Vector2(uvw1.x, uvw1.y));
 		surface_tool->set_uv2(Vector2(uvw2.x, uvw2.y));
-		surface_tool->set_normal(uvw3);
+		surface_tool->set_normal(Vector3(uvw3.x, uvw3.y, 1.0));
+		// This one gets clamped to [0,1], which should be fine for texture coords.
 		surface_tool->set_color(Color(uvw4.x, uvw4.y, uvw4.z, uvw1.z));
 
 		// Not enough slots left for normals. Also interpolating the 4D normals gives weird results, needs more experimentation.
@@ -206,13 +209,13 @@ void TetraMesh4D::update_cross_section_mesh() {
 		//// Vertices:
 
 		// Not storing actual position data in the vertex positions, x is an index, y is UVW data, z is unused.
-		surface_tool->add_vertex(Vector3(0.0, uvw2.z, 0.0));
-		surface_tool->add_vertex(Vector3(1.0, uvw2.z, 0.0));
-		surface_tool->add_vertex(Vector3(2.0, uvw2.z, 0.0));
+		surface_tool->add_vertex(Vector3(0.0, uvw2.z, uvw3.z));
+		surface_tool->add_vertex(Vector3(1.0, uvw2.z, uvw3.z));
+		surface_tool->add_vertex(Vector3(2.0, uvw2.z, uvw3.z));
 
-		surface_tool->add_vertex(Vector3(3.0, uvw2.z, 0.0));
-		surface_tool->add_vertex(Vector3(4.0, uvw2.z, 0.0));
-		surface_tool->add_vertex(Vector3(5.0, uvw2.z, 0.0));
+		surface_tool->add_vertex(Vector3(3.0, uvw2.z, uvw3.z));
+		surface_tool->add_vertex(Vector3(4.0, uvw2.z, uvw3.z));
+		surface_tool->add_vertex(Vector3(5.0, uvw2.z, uvw3.z));
 	}
 	surface_tool->commit(_cross_section_mesh);
 

--- a/model/tetra/tetra_mesh_4d.cpp
+++ b/model/tetra/tetra_mesh_4d.cpp
@@ -1,13 +1,15 @@
 #include "tetra_mesh_4d.h"
 
+#include "../../math/vector_4d.h"
+#include "../material_4d.h"
 #include "array_tetra_mesh_4d.h"
 
 #if GDEXTENSION
-#include <godot_cpp/classes/mesh.hpp>
+#include <godot_cpp/classes/material.hpp>
 #include <godot_cpp/classes/standard_material3d.hpp>
 #include <godot_cpp/classes/surface_tool.hpp>
 #elif GODOT_MODULE
-#include "scene/resources/mesh.h"
+#include "scene/resources/material.h"
 #include "scene/resources/surface_tool.h"
 #endif
 
@@ -47,6 +49,7 @@ Ref<ArrayMesh> TetraMesh4D::export_uvw_map_mesh() {
 void TetraMesh4D::tetra_mesh_clear_cache() {
 	_edge_positions_cache.clear();
 	_edge_indices_cache.clear();
+	mark_cross_section_mesh_dirty();
 }
 
 void TetraMesh4D::validate_material_for_mesh(const Ref<Material4D> &p_material) {
@@ -138,6 +141,82 @@ PackedVector4Array TetraMesh4D::get_edge_positions() {
 		}
 	}
 	return _edge_positions_cache;
+}
+
+void TetraMesh4D::update_cross_section_mesh() {
+	ERR_FAIL_NULL(_cross_section_mesh);
+	_cross_section_mesh->clear_surfaces();
+
+	Ref<SurfaceTool> surface_tool;
+	surface_tool.instantiate();
+	surface_tool->begin(Mesh::PRIMITIVE_TRIANGLES);
+	surface_tool->set_smooth_group(-1);
+
+	PackedVector4Array vertices = get_vertices();
+	PackedInt32Array cell_indices = get_cell_indices();
+	PackedVector3Array cell_uvws = get_cell_uvw_map();
+	PackedVector4Array cell_normals = get_cell_normals();
+	Ref<Material4D> material = get_material();
+	if (material.is_valid()) {
+		surface_tool->set_material(material->get_cross_section_material());
+	}
+	surface_tool->set_custom_format(0, SurfaceTool::CUSTOM_RGBA_FLOAT);
+	surface_tool->set_custom_format(1, SurfaceTool::CUSTOM_RGBA_FLOAT);
+	surface_tool->set_custom_format(2, SurfaceTool::CUSTOM_RGBA_FLOAT);
+	surface_tool->set_custom_format(3, SurfaceTool::CUSTOM_RGBA_FLOAT);
+	for (int i = 0; i < cell_indices.size(); i += 4) {
+		// Cramming a bunch of data where it fits. Each cell's cross section can be 0-2 triangles. We create two triangles for each cell
+		// with all the info about the cell and figure everything out in the vertex shader after transforms have been applied.
+		// As of 4.4.1, available slots are:
+		// - Vertex position (3)
+		// - Custom 0-3 (4 * 4)
+		// - UV1 and UV2 (2 * 2)
+		// - Normal (3)
+		// - Tangent (3)
+		// - Color (4)
+		// Slots that don't work:
+		// - Bone weights: get truncated, sorted, and normalized automatically
+		// - Binormal: available in shader, but computed in SurfaceTool from normal/tangent
+		//
+		// Some alternative strategies:
+		// - ImmediateMesh to compute cross-section on the CPU every frame, but that's likely slower.
+		// - Some kind of compute shader or custom render pipeline, but that's not supported on the Compatibility renderer.
+
+		//// Shared attrs for both triangles:
+
+		// Cell vertex positions: Using custom because there are conveniently four of them and they each take a vector4.
+		surface_tool->set_custom(0, Vector4D::to_color(vertices[cell_indices[i]]));
+		surface_tool->set_custom(1, Vector4D::to_color(vertices[cell_indices[i + 1]]));
+		surface_tool->set_custom(2, Vector4D::to_color(vertices[cell_indices[i + 2]]));
+		surface_tool->set_custom(3, Vector4D::to_color(vertices[cell_indices[i + 3]]));
+
+		// UVW texture coords, need 4*3 float slots.  Using UV, UV2, Normal, Color, and one vertex.y.
+		Vector3 uvw1 = cell_uvws[cell_indices[i]];
+		Vector3 uvw2 = cell_uvws[cell_indices[i + 1]];
+		Vector3 uvw3 = cell_uvws[cell_indices[i + 2]];
+		Vector3 uvw4 = cell_uvws[cell_indices[i + 3]];
+		surface_tool->set_uv(Vector2(uvw1.x, uvw1.y));
+		surface_tool->set_uv2(Vector2(uvw2.x, uvw2.y));
+		surface_tool->set_normal(uvw3);
+		surface_tool->set_color(Color(uvw4.x, uvw4.y, uvw4.z, uvw1.z));
+
+		// Not enough slots left for normals. Also interpolating the 4D normals gives weird results, needs more experimentation.
+		// Currently flat normals are computed in the vertex shader.
+
+		//// Vertices:
+
+		// Not storing actual position data in the vertex positions, x is an index, y is UVW data, z is unused.
+		surface_tool->add_vertex(Vector3(0.0, uvw2.z, 0.0));
+		surface_tool->add_vertex(Vector3(1.0, uvw2.z, 0.0));
+		surface_tool->add_vertex(Vector3(2.0, uvw2.z, 0.0));
+
+		surface_tool->add_vertex(Vector3(3.0, uvw2.z, 0.0));
+		surface_tool->add_vertex(Vector3(4.0, uvw2.z, 0.0));
+		surface_tool->add_vertex(Vector3(5.0, uvw2.z, 0.0));
+	}
+	surface_tool->commit(_cross_section_mesh);
+
+	// TODO Second surface for 4D "shadow" effect.
 }
 
 void TetraMesh4D::_bind_methods() {

--- a/model/tetra/tetra_mesh_4d.h
+++ b/model/tetra/tetra_mesh_4d.h
@@ -18,6 +18,8 @@ protected:
 	PackedInt32Array _edge_indices_cache;
 	PackedVector4Array _edge_positions_cache;
 
+	virtual void update_cross_section_mesh() override;
+
 public:
 	Ref<ArrayMesh> export_uvw_map_mesh();
 	void tetra_mesh_clear_cache();

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -72,6 +72,7 @@
 #include "physics/shapes/sphere_shape_4d.h"
 
 // Render.
+#include "render/cross_section/cross_section_rendering_engine_4d.h"
 #include "render/rendering_engine_4d.h"
 #include "render/rendering_server_4d.h"
 #include "render/wireframe_canvas/wireframe_canvas_rendering_engine_4d.h"
@@ -210,6 +211,7 @@ void initialize_4d_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(GhostPhysicsEngine4D);
 		GDREGISTER_CLASS(WireframeRenderCanvas4D);
 		GDREGISTER_CLASS(WireframeCanvasRenderingEngine4D);
+		GDREGISTER_CLASS(CrossSectionRenderingEngine4D);
 #endif // GDEXTENSION
 		PhysicsServer4D *physics_server = memnew(PhysicsServer4D);
 #ifdef TOOLS_ENABLED
@@ -221,6 +223,7 @@ void initialize_4d_module(ModuleInitializationLevel p_level) {
 		// Render.
 		RenderingServer4D *rendering_server = memnew(RenderingServer4D);
 		rendering_server->register_rendering_engine(memnew(WireframeCanvasRenderingEngine4D));
+		rendering_server->register_rendering_engine(memnew(CrossSectionRenderingEngine4D));
 		add_godot_singleton("RenderingServer4D", rendering_server);
 #ifdef TOOLS_ENABLED
 	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {

--- a/render/SCsub
+++ b/render/SCsub
@@ -5,5 +5,8 @@ Import("env_modules")
 
 env_4d = env_modules.Clone()
 
+env_4d.GLSL_HEADER("cross_section/cross_section_shader.glsl")
+
 env_4d.add_source_files(env.modules_sources, "*.cpp")
 env_4d.add_source_files(env.modules_sources, "wireframe_canvas/*.cpp")
+env_4d.add_source_files(env.modules_sources, "cross_section/*.cpp")

--- a/render/cross_section/cross_section_rendering_engine_4d.cpp
+++ b/render/cross_section/cross_section_rendering_engine_4d.cpp
@@ -1,0 +1,133 @@
+#include "cross_section_rendering_engine_4d.h"
+
+#include "../../model/mesh_instance_4d.h"
+#include "../../nodes/camera_4d.h"
+
+#if GDEXTENSION
+#include <godot_cpp/classes/rendering_server.hpp>
+#elif GODOT_MODULE
+#include "servers/rendering_server.h"
+#endif
+
+RID create_instance(const Viewport &viewport) {
+	ERR_FAIL_NULL_V(RenderingServer::get_singleton(), RID());
+	RID instance = RenderingServer::get_singleton()->instance_create();
+	// Vertex data on the mesh is wack. Culling will not work.
+	RenderingServer::get_singleton()->instance_set_ignore_culling(instance, true);
+	Ref<World3D> world = viewport.find_world_3d();
+	if (world.is_valid()) {
+		RenderingServer::get_singleton()->instance_set_scenario(instance, world->get_scenario());
+	}
+
+	return instance;
+}
+
+void CrossSectionRenderingEngine4D::render_frame() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(get_camera());
+	ERR_FAIL_NULL(get_viewport());
+	update_camera();
+	// Maps global to cameral-local, aka world space to view space.
+	TypedArray<MeshInstance4D> mesh_instances = get_mesh_instances();
+	TypedArray<Projection> modelview_basises = get_mesh_relative_basises();
+	PackedVector4Array modelview_origins = get_mesh_relative_positions();
+	size_t instance_index = 0;
+	if (mesh_instances.size() > _instances_3d.size()) {
+		_instances_3d.reserve(mesh_instances.size() - _instances_3d.size());
+	}
+	for (int mesh_index = 0; mesh_index < mesh_instances.size(); mesh_index++) {
+		MeshInstance4D *mesh_instance = Object::cast_to<MeshInstance4D>(mesh_instances[mesh_index]);
+		ERR_CONTINUE(mesh_instance == nullptr);
+
+		Ref<Mesh4D> mesh = mesh_instance->get_mesh();
+		if (!mesh.is_valid()) {
+			continue;
+		}
+		Ref<Mesh> mesh_3d = mesh->get_cross_section_mesh();
+		ERR_CONTINUE(!mesh_3d.is_valid());
+
+		while (_instances_3d.size() <= instance_index) {
+			_instances_3d.push_back(create_instance(*get_viewport()));
+		}
+		RID instance_3d = _instances_3d[instance_index];
+
+		RenderingServer::get_singleton()->instance_set_base(instance_3d, mesh_3d->get_rid());
+
+		Ref<Material4D> override_material = mesh_instance->get_material_override();
+		if (override_material.is_valid()) {
+			Ref<Material> override_material_3d = override_material->get_cross_section_material();
+			ERR_CONTINUE(!override_material_3d.is_valid());
+			RenderingServer::get_singleton()->instance_set_surface_override_material(instance_3d, 0, override_material_3d->get_rid());
+		}
+
+		Projection modelview_basis = modelview_basises[mesh_index];
+		Vector4 modelview_origin = modelview_origins[mesh_index];
+		RenderingServer::get_singleton()->instance_geometry_set_shader_parameter(instance_3d, "modelview_origin", modelview_origin);
+		// Can't pass a mat4 through instance uniforms, need to break up into columns.
+		RenderingServer::get_singleton()->instance_geometry_set_shader_parameter(instance_3d, "modelview_basis_x", modelview_basis.columns[0]);
+		RenderingServer::get_singleton()->instance_geometry_set_shader_parameter(instance_3d, "modelview_basis_y", modelview_basis.columns[1]);
+		RenderingServer::get_singleton()->instance_geometry_set_shader_parameter(instance_3d, "modelview_basis_z", modelview_basis.columns[2]);
+		RenderingServer::get_singleton()->instance_geometry_set_shader_parameter(instance_3d, "modelview_basis_w", modelview_basis.columns[3]);
+
+		instance_index++;
+	}
+	for (int i = instance_index; i < _instances_3d.size(); i++) {
+		RID instance = _instances_3d[i];
+		RenderingServer::get_singleton()->free_rid(instance);
+	}
+	_instances_3d.resize(instance_index);
+}
+
+void CrossSectionRenderingEngine4D::update_camera() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	if (!_cross_section_camera.is_valid()) {
+		ERR_FAIL_NULL(get_viewport());
+		_cross_section_camera = RenderingServer::get_singleton()->camera_create();
+		RenderingServer::get_singleton()->viewport_attach_camera(get_viewport()->get_viewport_rid(), _cross_section_camera);
+	}
+	// Only setting final 3D->2D projection stuff here. Can't pass the full Transform4D or even the basis as the camera's transform because it expects a Transform3D.
+	ERR_FAIL_NULL(get_camera());
+	Camera4D *camera = get_camera();
+	const float clip_near = camera->get_clip_near();
+	const float clip_far = camera->get_clip_far();
+	switch (camera->get_projection_type()) {
+		case Camera4D::PROJECTION4D_ORTHOGRAPHIC: {
+			RenderingServer::get_singleton()->camera_set_orthogonal(_cross_section_camera, camera->get_orthographic_size(), clip_near, clip_far);
+		} break;
+		case Camera4D::PROJECTION4D_PERSPECTIVE_4D: {
+			RenderingServer::get_singleton()->camera_set_perspective(_cross_section_camera, Math::rad_to_deg(camera->get_field_of_view_4d()), clip_near, clip_far);
+		} break;
+		case Camera4D::PROJECTION4D_PERSPECTIVE_3D: {
+			RenderingServer::get_singleton()->camera_set_perspective(_cross_section_camera, Math::rad_to_deg(camera->get_field_of_view_3d()), clip_near, clip_far);
+		} break;
+		case Camera4D::PROJECTION4D_PERSPECTIVE_DUAL: {
+			WARN_PRINT_ONCE("Dual-perspective is not supported by the Cross-section renderer. Use PESPECTIVE_3D, PERSPECTIVE_4D, or ORTHOGRAPHIC instead.");
+			RenderingServer::get_singleton()->camera_set_perspective(_cross_section_camera, Math::rad_to_deg(camera->get_field_of_view_3d()), clip_near, clip_far);
+		} break;
+	}
+}
+
+void CrossSectionRenderingEngine4D::setup_for_viewport() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	ERR_FAIL_NULL(get_viewport());
+	Ref<World3D> world = get_viewport()->find_world_3d();
+	// This will move instances between World3Ds, so adding a new viewport will remove all the instances from the previous viewport.
+	// TODO Per viewport instance cache?
+	if (world.is_valid()) {
+		RID scenario = world->get_scenario();
+		for (RID instance : _instances_3d) {
+			RenderingServer::get_singleton()->instance_set_scenario(instance, scenario);
+		}
+	}
+	if (_cross_section_camera.is_valid()) {
+		RenderingServer::get_singleton()->viewport_attach_camera(get_viewport()->get_viewport_rid(), _cross_section_camera);
+	}
+}
+
+CrossSectionRenderingEngine4D::~CrossSectionRenderingEngine4D() {
+	ERR_FAIL_NULL(RenderingServer::get_singleton());
+	for (RID instance : _instances_3d) {
+		RenderingServer::get_singleton()->free_rid(instance);
+	}
+	RenderingServer::get_singleton()->free_rid(_cross_section_camera);
+}

--- a/render/cross_section/cross_section_rendering_engine_4d.h
+++ b/render/cross_section/cross_section_rendering_engine_4d.h
@@ -1,12 +1,15 @@
 #pragma once
 
-#include "../rendering_engine_4d.h"
 #include <vector>
 
+#include "../rendering_engine_4d.h"
+
 #if GDEXTENSION
-#include <godot_cpp/variant/typed_array.hpp>
+#include <godot_cpp/classes/world3d.hpp>
+#include <godot_cpp/variant/rid.hpp>
 #elif GODOT_MODULE
-#include "core/variant/typed_array.h"
+#include "core/templates/rid.h"
+#include "scene/resources/3d/world_3d.h"
 #endif
 
 class CrossSectionRenderingEngine4D : public RenderingEngine4D {
@@ -15,9 +18,10 @@ class CrossSectionRenderingEngine4D : public RenderingEngine4D {
 private:
 	std::vector<RID> _instances_3d;
 	RID _cross_section_camera;
+	Ref<World3D> _cross_section_world_3d;
 
 	void update_camera();
-	bool cull_mesh(const MeshInstance4D &mesh, Projection basis, Vector4 position) const;
+	RID create_instance();
 
 protected:
 	static void _bind_methods() {}

--- a/render/cross_section/cross_section_rendering_engine_4d.h
+++ b/render/cross_section/cross_section_rendering_engine_4d.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "../rendering_engine_4d.h"
+#include <vector>
+
+#if GDEXTENSION
+#include <godot_cpp/variant/typed_array.hpp>
+#elif GODOT_MODULE
+#include "core/variant/typed_array.h"
+#endif
+
+class CrossSectionRenderingEngine4D : public RenderingEngine4D {
+	GDCLASS(CrossSectionRenderingEngine4D, RenderingEngine4D);
+
+private:
+	std::vector<RID> _instances_3d;
+	RID _cross_section_camera;
+
+	void update_camera();
+	bool cull_mesh(const MeshInstance4D &mesh, Projection basis, Vector4 position) const;
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual String get_friendly_name() const override { return "Cross-section"; }
+	virtual void setup_for_viewport() override;
+	virtual void render_frame() override;
+
+	virtual ~CrossSectionRenderingEngine4D();
+};

--- a/render/cross_section/cross_section_shader.glsl
+++ b/render/cross_section/cross_section_shader.glsl
@@ -1,6 +1,5 @@
 shader_type spatial;
 render_mode skip_vertex_transform;
-render_mode unshaded;
 
 // World space
 // Not allowed to pass matrices through instance uniforms, so have to unpack into vectors.
@@ -10,17 +9,112 @@ instance uniform vec4 modelview_basis_y;
 instance uniform vec4 modelview_basis_z;
 instance uniform vec4 modelview_basis_w;
 
-uniform vec4 albedo: source_color; 
+uniform vec4 albedo : source_color;
+uniform sampler3D albedo_texture : hint_default_white, source_color;
+
+varying vec3 uvw;
+
+// Maps from an arbitrary edge index to the indices of the vertices in a tetrahedron [a,b,c,d].
+const int TETRAHEDRON_EDGE_TO_VERTEX_MAP[] = {
+	0, 1,
+	0, 2,
+	0, 3,
+	1, 2,
+	1, 3,
+	2, 3
+};
+// Nonsense abstract lookup table for different cases of vertices above and below the cross-section plane. Derived by
+// sketching out 3D tetrahedra and hoping it also worked for 4D (it does).
+// 16 cases for number of vertices above and below the cross-section plane, each case leads to at most two triangles for 6 vertices.
+// Each triangle in the cross-section is made up of vertices that are interpolated along the edges of the tetrahedron,
+// falling where the edge intersetcs the cross-section plane. So this table is 16x6, 16 cases, 6 possible verts,
+// each value maps to an edge in the TETRAHEDRON_EDGE_TO_VERTEX_MAP. -1 indicates the vertex is unused for that case.
+// General pattern: one vertex above and three below is one triangle on the edges between the one vertex above and the rest,
+// one vertex below and three above is same but the winding order is flipped, two above and two below is two triangles in some awful pattern.
+// Flipping the bit pattern (i.e. flipping the tetrahedron) reverses the winding order of both triangles.
+const int CROSS_SECTION_LOOKUP[] = {
+	-1, -1, -1, -1, -1, -1, // 0000
+	0, 1, 2, -1, -1, -1, // 0001
+	0, 4, 3, -1, -1, -1, // 0010
+	2, 4, 1, 3, 1, 4, // 0011
+	1, 3, 5, -1, -1, -1, // 0100
+	0, 3, 2, 5, 2, 3, // 0101
+	1, 0, 5, 4, 5, 0, // 0110
+	2, 4, 5, -1, -1, -1, // 0111
+	2, 5, 4, -1, -1, -1, // 1000
+	1, 5, 0, 4, 0, 5, // 1001
+	0, 2, 3, 3, 2, 5, // 1010
+	1, 5, 3, -1, -1, -1, // 1011
+	2, 1, 4, 4, 1, 3, // 1100
+	0, 3, 4, -1, -1, -1, // 1101
+	0, 2, 1, -1, -1, -1, // 1110
+	-1, -1, -1, -1, -1, -1 // 1111
+};
+
+int get_face_lookup_index(float w1, float w2, float w3, float w4, int vertex_id) {
+	// Bitwise ops limit compatibility so summing instead.
+	int negative1 = w1 < 0.0 ? 1 : 0;
+	int negative2 = w2 < 0.0 ? 2 : 0;
+	int negative3 = w3 < 0.0 ? 4 : 0;
+	int negative4 = w4 < 0.0 ? 8 : 0;
+	int lookup_index = negative1 + negative2 + negative3 + negative4;
+
+	// First index in the group of three that the indicated vertex belongs to.
+	return (lookup_index * 6) + vertex_id - (vertex_id % 3);
+}
+
+vec3 slice_edge(vec4 v1, vec4 v2) {
+	float mix_weight = v1.w / (v1.w - v2.w);
+	return mix(v1, v2, mix_weight).xyz;
+}
 
 void vertex() {
-    mat4 modelview_basis = mat4(modelview_basis_x, modelview_basis_y, modelview_basis_z, modelview_basis_w);
-    // Make an arbitrary triangle from the cell so there's something on the screen.
-    vec4 position = (VERTEX.x == 1.0 ? CUSTOM0 : (VERTEX.y == 1.0 ? CUSTOM1 : CUSTOM2));
-    position = (modelview_basis * position) + modelview_origin;
-    POSITION = PROJECTION_MATRIX * vec4(position.xyz, 1.0);
-    // TODO actual cross-sectioning
+	mat4 modelview_basis = mat4(modelview_basis_x, modelview_basis_y, modelview_basis_z, modelview_basis_w);
+
+	vec4 verts[] = { CUSTOM0, CUSTOM1, CUSTOM2, CUSTOM3 };
+	verts[0] = (modelview_basis * verts[0]) + modelview_origin;
+	verts[1] = (modelview_basis * verts[1]) + modelview_origin;
+	verts[2] = (modelview_basis * verts[2]) + modelview_origin;
+	verts[3] = (modelview_basis * verts[3]) + modelview_origin;
+
+	vec3 uvws[] = { vec3(UV, COLOR.a), vec3(UV2, VERTEX.y), vec3(NORMAL.xy / NORMAL.z, VERTEX.z), COLOR.rgb };
+
+	int vertex_id = int(VERTEX.x);
+	int face = get_face_lookup_index(verts[0].w, verts[1].w, verts[2].w, verts[3].w, vertex_id);
+	if (CROSS_SECTION_LOOKUP[face] == -1) {
+		// This vertex is unused, cull
+		POSITION = vec4(0.0, 0.0, CLIP_SPACE_FAR, 1.0);
+	} else {
+		int position_edge = CROSS_SECTION_LOOKUP[face + (vertex_id % 3)];
+		int edge_vert1 = TETRAHEDRON_EDGE_TO_VERTEX_MAP[position_edge * 2];
+		int edge_vert2 = TETRAHEDRON_EDGE_TO_VERTEX_MAP[(position_edge * 2) + 1];
+		vec4 position1 = verts[edge_vert1];
+		vec4 position2 = verts[edge_vert2];
+		float mix_weight = position1.w / (position1.w - position2.w);
+		vec4 position = mix(position1, position2, mix_weight);
+		// Vertex is view space and used for lighting, position is clip space and used for rasterizing.
+		VERTEX = position.xyz;
+		POSITION = PROJECTION_MATRIX * vec4(position.xyz, 1.0);
+
+		uvw = mix(uvws[edge_vert1], uvws[edge_vert2], mix_weight);
+
+		// Compute flat normals.
+		int face_v1_edge = CROSS_SECTION_LOOKUP[face];
+		int face_v2_edge = CROSS_SECTION_LOOKUP[face + 1];
+		int face_v3_edge = CROSS_SECTION_LOOKUP[face + 2];
+		vec3 face_v1 = slice_edge(verts[TETRAHEDRON_EDGE_TO_VERTEX_MAP[face_v1_edge * 2]], verts[TETRAHEDRON_EDGE_TO_VERTEX_MAP[face_v1_edge * 2 + 1]]);
+		vec3 face_v2 = slice_edge(verts[TETRAHEDRON_EDGE_TO_VERTEX_MAP[face_v2_edge * 2]], verts[TETRAHEDRON_EDGE_TO_VERTEX_MAP[face_v2_edge * 2 + 1]]);
+		vec3 face_v3 = slice_edge(verts[TETRAHEDRON_EDGE_TO_VERTEX_MAP[face_v3_edge * 2]], verts[TETRAHEDRON_EDGE_TO_VERTEX_MAP[face_v3_edge * 2 + 1]]);
+		vec3 normal = normalize(cross(face_v3 - face_v1, face_v2 - face_v1));
+		vec3 tangent = normalize(face_v2 - face_v1);
+		vec3 binormal = normalize(cross(normal, tangent));
+		NORMAL = normal;
+		TANGENT = tangent;
+		BINORMAL = binormal;
+	}
 }
 
 void fragment() {
-    ALBEDO = albedo.rgb;
+	ALBEDO = albedo.rgb * texture(albedo_texture, uvw).rgb;
+	NORMAL = normalize(NORMAL);
 }

--- a/render/cross_section/cross_section_shader.glsl
+++ b/render/cross_section/cross_section_shader.glsl
@@ -1,0 +1,26 @@
+shader_type spatial;
+render_mode skip_vertex_transform;
+render_mode unshaded;
+
+// World space
+// Not allowed to pass matrices through instance uniforms, so have to unpack into vectors.
+instance uniform vec4 modelview_origin;
+instance uniform vec4 modelview_basis_x;
+instance uniform vec4 modelview_basis_y;
+instance uniform vec4 modelview_basis_z;
+instance uniform vec4 modelview_basis_w;
+
+uniform vec4 albedo: source_color; 
+
+void vertex() {
+    mat4 modelview_basis = mat4(modelview_basis_x, modelview_basis_y, modelview_basis_z, modelview_basis_w);
+    // Make an arbitrary triangle from the cell so there's something on the screen.
+    vec4 position = (VERTEX.x == 1.0 ? CUSTOM0 : (VERTEX.y == 1.0 ? CUSTOM1 : CUSTOM2));
+    position = (modelview_basis * position) + modelview_origin;
+    POSITION = PROJECTION_MATRIX * vec4(position.xyz, 1.0);
+    // TODO actual cross-sectioning
+}
+
+void fragment() {
+    ALBEDO = albedo.rgb;
+}


### PR DESCRIPTION
For #5 

Adds a renderer that slices a 4D tetrahedron mesh on the GPU in the vertex shader. Works by packing data wherever it fits on Godot's rendering server and reinterpreting it in the shader. 

In a decent state but there are a couple issues I'm aware of:
- ~3D editor preview is broken, the preview camera's transform isn't passed to the shader so 4D meshes stay fixed in place and don't move with the camera view, probably means adding support for 3D cameras~
- ~UVWs look off, can't tell if they're wrong on the 4D mesh or getting mangled on the way to the shader. Haven't had the brainpower to delve into the fourth dimension and debug that.~
- Missing some kind of support for wireframe meshes, should be possible but not quite sure what that looks like. Should be able to re-use the same shader with a mesh using line primitives.
- Missing the "shadow" effect to give some indication of the rest of the mesh, should be doable with another shader on `next_pass` for the first shader, may need another surface on the mesh as well


