### PR TITLE
Fix out of bounds error with mesh merging

### DIFF
--- a/model/wire/array_wire_mesh_4d.cpp
+++ b/model/wire/array_wire_mesh_4d.cpp
@@ -73,10 +73,10 @@ void ArrayWireMesh4D::merge_with(const Ref<ArrayWireMesh4D> &p_other, const Tran
 	if (other_material.is_valid()) {
 		Ref<Material4D> self_material = get_material();
 		if (self_material.is_valid()) {
-			self_material->merge_with(other_material, start_vertex_count, other_vertex_count);
+			self_material->merge_with(other_material, start_edge_count / 2, other_edge_count / 2);
 		} else if (other_material->get_albedo_color_array().size() > 0) {
 			self_material.instantiate();
-			self_material->merge_with(other_material, start_vertex_count, other_vertex_count);
+			self_material->merge_with(other_material, start_edge_count / 2, other_edge_count / 2);
 			set_material(self_material);
 		} else {
 			set_material(other_material);


### PR DESCRIPTION
There's an issue with ArrayWireMesh4D.merge_with where it will crash due to an invalid index into the albedo color array.
1. It should be edges, not vertices.
2. The edge index count should be divided by two before passing it into the WireMaterial4D.merge_with function, since there should be twice the amount of indices to edges.